### PR TITLE
Add borderRadius param

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Append the query param `theme=:theme` to the end of the URL, replacing `:theme` 
 
 Append the query param `bg=:color` to the end of the URL, replacing `:color` with a hex color of your choice (omit the #)
 
+### ___Border Radius___
+
+Append the query param `borderRadius=:radius` to the end of the URL, replacing `:radius` with a radius of your choice. (default `10px`)
+
 ### ___Toggle Animated Avatar___
 
 If you have an animated avatar, append the query param `animated=:bool` to the end of the URL, replacing `:bool` with `true` or `false`. This is set to `true` by default.

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -11,6 +11,7 @@ type Parameters = {
     animated?: string;
     hideDiscrim?: string;
     hideStatus?: string;
+    borderRadius?: string;
 }
 
 const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<string> => {
@@ -24,7 +25,8 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
         backgroundColor: string = '1a1c1f',
         theme = 'dark',
         discrim = 'show',
-        hideStatus = 'false';
+        hideStatus = 'false',
+        borderRadius = '10px';
 
     if (body.data.activities[0]?.emoji?.animated) statusExtension = "gif";
     if (body.data.discord_user.avatar && body.data.discord_user.avatar.startsWith("a_")) avatarExtension = "gif";
@@ -37,6 +39,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
         theme = 'light';
     }
     if (params.bg) backgroundColor = params.bg;
+    if (params.borderRadius) borderRadius = params.borderRadius;
 
     switch (body.data.discord_status) {
         case "online":
@@ -74,7 +77,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                         display: flex;
                         flex-direction: column;
                         padding: 5px;
-                        border-radius: 10px;
+                        border-radius: ${borderRadius};
                     ">
                         <div style="
                             width: 400px;


### PR DESCRIPTION
Adds a `borderRadius` query parameter to allow customization of the `border-radius` property of the outer div. Defaults to `10px`, which was already the forced value.

Also updated the README with info on the parameter.