### PR TITLE
Changing settings so it works when redis is down.

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -98,7 +98,10 @@ export default function Home({ userCount }: { userCount: number }) {
 }
 
 export async function getServerSideProps(ctx: any) {
-    let userCount = await axios.get("https://lanyard.cnrad.dev/api/getUserCount").then(res => res.data.count);
+    let userCount = await axios
+        .get("https://lanyard.cnrad.dev/api/getUserCount", { timeout: 1000 })
+        .then(res => res.data.count)
+        .catch(() => 0);
 
     return {
         props: { userCount },

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -1,5 +1,9 @@
 import Redis from "ioredis";
 
-const redis = new Redis(process.env.REDIS_URL);
+const redis = new Redis(process.env.REDIS_URL, {
+    connectTimeout: 1000,
+    lazyConnect: false,
+    maxRetriesPerRequest: 1,
+});
 
 export default redis;


### PR DESCRIPTION
This PR sets Redis' connection timeout to 1000ms, and allows only 1 retry, this prevents the function from returning 504 because it takes too long constantly retrying redis.

Also sets the timeout to 1000ms on the axios request in your getServerSideProps, and returns 0 for the count on catch, which allows the index page to load, 

This will increase the load time of the routes, but it will be normal when the redis server is actually accepting connections properly.