### PR TITLE
[Spotify] Display song duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -42,6 +42,16 @@ const elapsedTime = (timestamp: any) => {
     )}:${("0" + secondsDifference).slice(-2)}`;
 };
 
+const timeLeft = (start: number, end: number) => {
+    let unixStart = start / 1000;
+    let unixEnd = end / 1000;
+
+    let minutesLeft = Math.floor((unixEnd - unixStart) / 60);
+    let secondsLeft = Math.floor((unixEnd - unixStart) % 60);
+
+    return `${minutesLeft}:${secondsLeft}`
+}
+
 const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<string> => {
     let { data } = body;
 
@@ -403,7 +413,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                     ">
                         <p style="font-size: 0.75rem; font-weight: bold; color: ${
                             theme === "dark" ? "#1CB853" : "#0d943d"
-                        }; margin-bottom: 15px;">LISTENING TO SPOTIFY...</p>
+                        }; margin-bottom: -3px;">LISTENING TO SPOTIFY...</p>
                         <p style="
                             height: 15px;
                             color: ${theme === "dark" ? "#fff" : "#000"};
@@ -423,6 +433,15 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                             text-overflow: ellipsis;
                             color: ${theme === "dark" ? "#ccc" : "#777"};
                         ">By ${escape(data.spotify.artist)}</p>
+                        <p xmlns="http://www.w3.org/1999/xhtml" style="
+                            color: #ccc;
+                            overflow: hidden;
+                            white-space: nowrap;
+                            font-size: 0.85rem;
+                            text-overflow: ellipsis;
+                            height: 15px;
+                            margin: 7px 0;
+                        ">${timeLeft(data.spotify.timestamps.start,data.spotify.timestamps.end)}</p>
                     </div>
                 </div>
             ` : ``

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -47,9 +47,11 @@ const timeLeft = (start: number, end: number) => {
     let unixEnd = end / 1000;
 
     let minutesLeft = Math.floor((unixEnd - unixStart) / 60);
+    let minutes = minutesLeft < 10 ? "0" + minutesLeft : minutesLeft;
     let secondsLeft = Math.floor((unixEnd - unixStart) % 60);
+    let seconds = secondsLeft < 10 ? "0" + secondsLeft : secondsLeft;
 
-    return `${minutesLeft}:${secondsLeft}`
+    return `${minutes}:${seconds}`
 }
 
 const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<string> => {


### PR DESCRIPTION
This PR:

* Displays song duration for Spotify status
* Bumps up the version from `0.1.0` to `0.1.1`

Preview

![image](https://user-images.githubusercontent.com/79590499/179470389-43ed3293-dc8c-4ae8-b017-2ff82cef83f8.png)
![image](https://user-images.githubusercontent.com/79590499/179470457-38ed8a7d-50ab-4c20-a3eb-665d945da37c.png)

