### PR TITLE
Add option to hide Discord profile with hideProfile=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ If you don't want people seeing the elapsed time on an activity, append the quer
 
 If you don't want people seeing the badges you have on Discord, append the query param `hideBadges=true` to the end of the URL. Badges are shown by default.
 
+### ___Hide Profile___
+
+If you don't want people seeing the profile you have on Discord, append the query param `hideProfile=true` to the end of the URL. Profile are shown by default.
+
 ## ___Example URL and result___
 
 ```

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -135,8 +135,8 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
     activity = Array.isArray(activities) ? activities[0] : activities;
 
     return `
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" width="410px" height="210px">
-                <foreignObject x="0" y="0" width="410" height="210">
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xhtml="http://www.w3.org/1999/xhtml" width="410px" height="${hideProfile === "true" ? "130px" : "210px"}">
+                <foreignObject x="0" y="0" width="410" height="${hideProfile === "true" ? "130" : "210"}">
                     <div xmlns="http://www.w3.org/1999/xhtml" style="
                         position: absolute;
                         width: 400px;

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -15,6 +15,7 @@ type Parameters = {
     hideStatus?: string;
     hideTimestamp?: string;
     hideBadges?: string;
+    hideProfile?: string;
     borderRadius?: string;
     idleMessage?: string;
 };
@@ -55,6 +56,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
         hideStatus = "false",
         hideTimestamp = "false",
         hideBadges = "false",
+        hideProfile = "false",
         borderRadius = "10px",
         idleMessage = "I'm not currently doing anything!";
 
@@ -65,6 +67,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
     if (params.hideTimestamp === "true") hideTimestamp = "true";
     if (params.hideBadges === "true") hideBadges = "true";
     if (params.hideDiscrim === "true") discrim = "hide";
+    if (params.hideProfile === "true") hideProfile = "true";
     if (params.theme === "light") {
         backgroundColor = "#eee";
         theme = "light";
@@ -137,7 +140,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                     <div xmlns="http://www.w3.org/1999/xhtml" style="
                         position: absolute;
                         width: 400px;
-                        height: 200px;
+                        height: ${hideProfile === "true" ? "120px" : "200px"};
                         inset: 0;
                         background-color: #${backgroundColor};
                         color: ${theme === "dark" ? "#fff" : "#000"};
@@ -148,6 +151,9 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                         padding: 5px;
                         border-radius: ${borderRadius};
                     ">
+                    
+                    ${
+                        hideProfile === "true" ? "" : `
                         <div style="
                             width: 400px;
                             height: 100px;
@@ -252,7 +258,8 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                                 </h1>` : ``
                                 }
                             </div>
-                        </div>
+                        </div>`
+                    }
 
                         ${
                             activity ? `


### PR DESCRIPTION
# Justification
This is useful for someone who want to custom their profile layout and remove the one that from the image, or for people who just want to get a clean activity image.

# Images
It also supports other options, so it doesn't break the previous one
![image](https://user-images.githubusercontent.com/61258338/204121289-3ae0faab-2a0e-43bb-9d27-6424a9eedd01.png)
![image](https://user-images.githubusercontent.com/61258338/204121292-9e58b6da-c55a-41b5-a0b4-f371070543fe.png)
![image](https://user-images.githubusercontent.com/61258338/204121416-e81e2c5c-8595-4a15-a949-cfa41675475e.png)

