### PR TITLE
feat: add support for `endTimestamp`

### DIFF
--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -26,7 +26,7 @@ const formatTime = (timestamps: any) => {
     let startTime = new Date(end || start).getTime();
     let endTime = Number(new Date());
     let difference = end ? (startTime - endTime) / 1000 : (endTime - startTime) / 1000;
-    if (difference < 0) return "00:00";
+    if (difference < 0) return `00:00 ${end ? "left" : "elapsed"}`;
 
     // we only calculate them, but we don't display them.
     // this fixes a bug in the Discord API that does not send the correct timestamp to presence.

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -321,7 +321,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                                 <div style="
                                     color: #999;
                                     margin-top: ${
-                                        activity.timestamps?.start && hideTimestamp !== "true"
+                                        (activity.timestamps?.start || activity.timestamp?.end) && hideTimestamp !== "true"
                                             ? "-6px"
                                             : "5px"
                                     };

--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -20,10 +20,13 @@ type Parameters = {
     idleMessage?: string;
 };
 
-const elapsedTime = (timestamp: any) => {
-    let startTime = timestamp;
+const formatTime = (timestamps: any) => {
+    const { start, end } = timestamps;
+    // endTimestamp is prioritized over startTimestamp, similar to Discord's behavior, and displayed accordingly.
+    let startTime = new Date(end || start).getTime();
     let endTime = Number(new Date());
-    let difference = (endTime - startTime) / 1000;
+    let difference = end ? (startTime - endTime) / 1000 : (endTime - startTime) / 1000;
+    if (difference < 0) return "00:00";
 
     // we only calculate them, but we don't display them.
     // this fixes a bug in the Discord API that does not send the correct timestamp to presence.
@@ -40,7 +43,7 @@ const elapsedTime = (timestamp: any) => {
 
     return `${hoursDifference >= 1 ? ("0" + hoursDifference).slice(-2) + ":" : ""}${("0" + minutesDifference).slice(
         -2
-    )}:${("0" + secondsDifference).slice(-2)}`;
+    )}:${("0" + secondsDifference).slice(-2)} ${end ? "left" : "elapsed"}`;
 };
 
 const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<string> => {
@@ -367,7 +370,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                                                 }</p>` : ``
                                         }
                                         ${
-                                            activity.timestamps?.start && hideTimestamp !== "true" ? `
+                                            (activity.timestamps?.end || activity.timestamps?.start) && hideTimestamp !== "true" ? `
                                             <p style="
                                                 color: ${theme === "dark" ? "#ccc" : "#777"};
                                                 overflow: hidden;
@@ -376,7 +379,7 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                                                 text-overflow: ellipsis;
                                                 height: 15px;
                                                 margin: 7px 0;
-                                            ">${elapsedTime(new Date(activity.timestamps.start).getTime())} elapsed</p>`
+                                            ">${formatTime(activity.timestamps)}</p>`
                                                 : ``
                                         }
                                 </div>


### PR DESCRIPTION
Seems like this is supported by Lanyard, but not utilized here so it seems like a good addition.
Added `Time Left` displayed on activities.
Tested and currently deployed live on [my fork](lanyard.kyrie25.me) if you want to make sure the changes works.

