### PR TITLE
Prevent clan tag (name) from wrapping to multiple lines

### DIFF
--- a/src/renderCard.tsx
+++ b/src/renderCard.tsx
@@ -305,7 +305,10 @@ const renderCard = async (body: LanyardTypes.Root, params: Parameters): Promise<
                                             height: 100%;
                                         ">
                                             <img src="data:image/png;base64,${clanBadge!}" />
-                                            <p style="margin-bottom: 1.1rem">${escape(data.discord_user.clan!.tag)}</p>
+                                            <p style="
+                                                margin-bottom: 1.1rem;
+                                                white-space: nowrap;
+                                            ">${escape(data.discord_user.clan!.tag)}</p>
                                         </span>
                                     `}
 


### PR DESCRIPTION
Before - 
![before-759180080328081450](https://github.com/user-attachments/assets/99e87e0b-4c4f-411f-b20a-d34354bce01c)


After -
![759180080328081450](https://github.com/user-attachments/assets/5d9cf6cb-e271-41b7-a226-7b2b5afa4304)
