### PR TITLE
fix(cardRender): change artist separator from "; " to ", "

### DIFF
--- a/src/utils/renderCard.tsx
+++ b/src/utils/renderCard.tsx
@@ -635,7 +635,7 @@ async function renderCard(body: LanyardTypes.Root, params: Parameters): Promise<
                     color: theme === "dark" ? "#ccc" : "#777",
                   }}
                 >
-                  By {data.spotify.artist}
+                  By {data.spotify.artist.replace(/; /g, ", ")}
                 </p>
               </div>
             </div>


### PR DESCRIPTION
On Discord, when a song has multiple artists, their names are separated by a comma and space (", ") instead of a semicolon ("; ").

This PR updates the artist separator from "; " to ", ", making the display consistent with Discord's native formatting. 