### PR TITLE
fix: disable no-img-element rule in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,11 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
Due to <Image /> being incompatible with server sided SVG generation, <img /> should obiously stay as the method for downloading the images. I added a warning silencer for the linter so it stops bugging about that, which will allow new contributors to be able to run `next build` without needing the `--no-lint` flag, which I had to do before silencing