### PR TITLE
Fix mp:external assets for missing activity images on cloudflare workers

### DIFF
--- a/src/utils/fetchUserImages.ts
+++ b/src/utils/fetchUserImages.ts
@@ -79,10 +79,7 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
   if (activity?.assets?.large_image)
     assetLargeImage = await encodeBase64(
       activity.assets?.large_image.startsWith("mp:external/")
-        ? `https://media.discordapp.net/${activity.assets.large_image.replace(
-            "mp:",
-            ""
-          )}`
+        ? `${activity.assets.large_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
         : `https://cdn.discordapp.com/app-assets/${activity.application_id}/${activity.assets.large_image}.webp`,
       ImageSize.ACTIVITY_LARGE,
       settings.theme
@@ -91,10 +88,7 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
   if (activity?.assets?.small_image)
     assetSmallImage = await encodeBase64(
       activity.assets.small_image.startsWith("mp:external/")
-        ? `https://media.discordapp.net/${activity.assets.small_image.replace(
-            "mp:",
-            ""
-          )}`
+        ? `${activity.assets.small_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
         : `https://cdn.discordapp.com/app-assets/${activity.application_id}/${activity.assets.small_image}.webp`,
       ImageSize.ACTIVITY_SMALL,
       settings.theme


### PR DESCRIPTION
Since production is deployed on cloudflare mp:external assets do not work due to Discord blocking requests to their media proxy from cloudflares network.

To fix this we just use the URL directly instead, going around their media proxy altogether.

![image](https://dustin.pics/8af292fe6940ce97.png)

To see a deployed example:
https://lanyard-profile-readme.dstn.workers.dev/api/156114103033790464
If I do not have an activity that has external assets just your ID.