### PR TITLE
feat: render music activity concurrently with games and add fallback RPC icon fetch

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,4 +8,6 @@ export default nextConfig;
 
 // added by create cloudflare to enable calling `getCloudflareContext()` in `next dev`
 import { initOpenNextCloudflareForDev } from '@opennextjs/cloudflare';
-initOpenNextCloudflareForDev();
+if (process.env.NODE_ENV === "development") {
+  initOpenNextCloudflareForDev();
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "dev": "next dev",
     "build": "next build",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
@@ -16,7 +17,7 @@
     "ioredis": "^5.6.0",
     "lucide-react": "^0.487.0",
     "motion": "^12.6.3",
-    "next": "^15.2.8",
+    "next": "15.2.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sharp": "^0.34.1",

--- a/src/app/api/[id]/route.ts
+++ b/src/app/api/[id]/route.ts
@@ -4,6 +4,8 @@ import { Root } from "@/utils/LanyardTypes";
 import { extractSearchParams } from "@/utils/extractSearchParams";
 import { fetchUserImages } from "@/utils/fetchUserImages";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -79,7 +81,9 @@ export async function GET(
     return new Response(svgString, {
       headers: {
         "Content-Type": "image/svg+xml",
-        "Cache-Control": "public, max-age=60, s-maxage=60",
+        "Cache-Control": "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
+        "CDN-Cache-Control": "no-store",
+        "Vercel-CDN-Cache-Control": "no-store",
       },
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -300,10 +300,9 @@ const MainSection = ({
       {userId.length > 0 && isSnowflake(userId) ? (
         <img
           src={url}
-          height={280}
-          width={500}
           alt="Your Lanyard Banner"
           className="mx-auto"
+          style={{ height: "auto", width: "100%", maxWidth: "410px" }}
         />
       ) : (
         <div className="w-full min-h-64 rounded-xl border border-white/10 bg-gray-50/5 flex items-center justify-center text-white/25 font-mono text-sm px-16 text-center">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, JSX } from "react";
+import React, { useState, useEffect, JSX } from "react";
 import { motion } from "motion/react";
 import { isSnowflake } from "@/utils/snowflake";
 import { IParameterInfo, PARAMETER_INFO } from "@/utils/parameters";
@@ -9,10 +9,17 @@ import { InfoTooltip } from "@/components/Popover";
 import { cn, filterLetters } from "@/utils/helpers";
 
 export default function Home() {
+  const [originUrl, setOriginUrl] = useState("");
+
+  useEffect(() => {
+    setOriginUrl(window.location.origin);
+  }, []);
+
   const ORIGIN_URL =
-    process.env.NODE_ENV === "development"
+    originUrl ||
+    (process.env.NODE_ENV === "development"
       ? "http://localhost:3000"
-      : "https://lanyard.cnrad.dev";
+      : "https://lanyard.cnrad.dev");
 
   const [userId, setUserId] = useState("");
   const [userError, setUserError] = useState<string | JSX.Element>();

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,6 +1,6 @@
 import { Activity, Data } from "@/utils/LanyardTypes";
 import { Badges, UnknownIconDark, UnknownIconLight } from "@/utils/badges";
-import { elapsedTime, getFlags } from "@/utils/helpers";
+import { elapsedTime, getFlags, getImageDataUri } from "@/utils/helpers";
 import { ProfileSettings } from "@/utils/parameters";
 import React, { DetailedHTMLProps, HTMLAttributes } from "react";
 
@@ -11,8 +11,7 @@ interface ProfileCardProps {
     avatar: string | null;
     avatarDecoration: string | null;
     clanBadge: string | null;
-    assetLargeImage: string | null;
-    assetSmallImage: string | null;
+    activityImages: Array<{ largeImage: string | null; smallImage: string | null }>;
     userEmoji: string | null;
     albumCover: string | null;
   };
@@ -47,8 +46,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
     avatar,
     avatarDecoration,
     clanBadge,
-    assetLargeImage,
-    assetSmallImage,
+    activityImages,
     userEmoji,
     albumCover,
   } = images;
@@ -87,45 +85,53 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
     .filter(
       (activity) => !ignoreAppId?.includes(activity.application_id ?? "")
     );
-  const activity: Activity | undefined =
-    activities.length > 0 ? activities[0] : undefined;
-
   // Non-Spotify listening activity (e.g. Apple Music via discord-music-presence)
   const musicActivity: Activity | undefined = !data.listening_to_spotify
     ? data.activities.find((a) => a.type === 2)
     : undefined;
   const isAppleMusic = musicActivity?.name === "Apple Music";
-  const showMusicActivity = !!(musicActivity && !activity && !(isAppleMusic && hideAppleMusic));
+  const showMusicActivity = !!(musicActivity && !(isAppleMusic && hideAppleMusic));
 
   const width = "410px";
   const hasAnyListening = data.listening_to_spotify || showMusicActivity;
 
+  const showActivitySection = hideActivity !== true &&
+    !(hideActivity === "whenNotUsed" && activities.length === 0 && !hasAnyListening);
+
+  const ACTIVITY_BLOCK_H = 110;
+
+  // Calculate activity section height based on visible content
+  const activitySectionH = (() => {
+    if (!showActivitySection) return 0;
+
+    let height = 0;
+    if (activities.length > 0) {
+      height += activities.length * ACTIVITY_BLOCK_H;
+    }
+
+    const hasSpotify = data.listening_to_spotify && !hideSpotify;
+    if (hasSpotify) {
+      height += ACTIVITY_BLOCK_H;
+    } else if (showMusicActivity) {
+      height += ACTIVITY_BLOCK_H;
+    }
+
+    if (activities.length === 0 && !hasSpotify && !showMusicActivity) {
+      height = ACTIVITY_BLOCK_H; // idle message
+    }
+
+    return height;
+  })();
+
   const height = (() => {
-    if (hideProfile) return "130";
-    if (hideActivity === true) return "91";
-    if (
-      hideActivity === "whenNotUsed" &&
-      !activity &&
-      !hasAnyListening
-    )
-      return "91";
-    if (hideSpotify && data.listening_to_spotify) return "210";
-    return "210";
+    if (hideProfile && activitySectionH === 0) return "40";
+    if (hideProfile) return String(activitySectionH + 20);
+    if (activitySectionH === 0) return "91";
+    return String(100 + activitySectionH);
   })();
 
   // Calculate height of main div element
-  const divHeight = (() => {
-    if (hideProfile) return "120";
-    if (hideActivity === true) return "81";
-    if (
-      hideActivity === "whenNotUsed" &&
-      !activity &&
-      !hasAnyListening
-    )
-      return "81";
-    if (hideSpotify && data.listening_to_spotify) return "200";
-    return "200";
-  })();
+  const divHeight = String(Number(height) - 10);
 
   const ForeignDiv = (
     props: DetailedHTMLProps<
@@ -168,11 +174,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                 display: "flex",
                 flexDirection: "row",
                 paddingBottom: "5px",
-                borderBottom:
-                  hideActivity === true ||
-                  (hideActivity === "whenNotUsed" &&
-                    !activity &&
-                    !hasAnyListening)
+                borderBottom: !showActivitySection
                     ? "none"
                     : `solid 0.5px ${
                         theme === "dark"
@@ -191,7 +193,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                 }}
               >
                 <img
-                  src={`data:image/png;base64,${avatar}`}
+                  src={getImageDataUri(avatar)}
                   alt="User Avatar"
                   style={{
                     borderRadius: "50%",
@@ -208,7 +210,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                 !data.discord_user.avatar_decoration_data ? null : (
                   <>
                     <img
-                      src={`data:image/webp;base64,${avatarDecoration!}`}
+                      src={getImageDataUri(avatarDecoration!)}
                       alt="Avatar Decoration"
                       style={{
                         display: "block",
@@ -297,7 +299,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                       }}
                     >
                       <img
-                        src={`data:image/png;base64,${clanBadge!}`}
+                        src={getImageDataUri(clanBadge!)}
                         alt="Clan Badge"
                         style={{
                           width: "16px",
@@ -318,7 +320,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                         <img
                           key={v}
                           alt={v}
-                          src={`data:image/png;base64,${Badges[v]}`}
+                          src={getImageDataUri(Badges[v])}
                           style={{
                             width: "auto",
                             height: "20px",
@@ -357,7 +359,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                   >
                     {userStatus.emoji?.id ? (
                       <img
-                        src={`data:image/png;base64,${userEmoji}`}
+                        src={getImageDataUri(userEmoji)}
                         alt="User Status Emoji"
                         style={{
                           width: "15px",
@@ -387,12 +389,14 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
             </div>
           ) : null}
 
-          {activity ? (
+          {activities.length > 0 && showActivitySection
+            ? activities.map((activity, index) => (
             <div
+              key={activity.application_id || index}
               style={{
                 display: "flex",
                 flexDirection: "row",
-                height: "120px",
+                height: `${ACTIVITY_BLOCK_H}px`,
                 marginLeft: "15px",
                 fontSize: "0.75rem",
                 paddingTop: "18px",
@@ -405,9 +409,9 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                   height: "auto",
                 }}
               >
-                {activity.assets?.large_image ? (
+                {activityImages[index]?.largeImage ? (
                   <img
-                    src={`data:image/png;base64,${assetLargeImage}`}
+                    src={getImageDataUri(activityImages[index]?.largeImage)}
                     alt="Activity Large Image"
                     style={{
                       width: "80px",
@@ -418,9 +422,9 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                   />
                 ) : (
                   <img
-                    src={`data:image/png;base64,${
+                    src={getImageDataUri(
                       theme === "dark" ? UnknownIconLight : UnknownIconDark
-                    }`}
+                    )}
                     alt="Unknown Icon"
                     style={{
                       width: "70px",
@@ -432,7 +436,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
 
                 {activity.assets?.small_image ? (
                   <img
-                    src={`data:image/png;base64,${assetSmallImage}`}
+                    src={getImageDataUri(activityImages[index]?.smallImage)}
                     alt="Activity Small Image"
                     style={{
                       width: "30px",
@@ -521,12 +525,9 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
                 ) : null}
               </div>
             </div>
-          ) : null}
-          {data.listening_to_spotify &&
-          !activity &&
-          !hideSpotify &&
-          data.activities[Object.keys(data.activities).length - 1].type ===
-            2 ? (
+          ))
+          : null}
+          {data.listening_to_spotify && showActivitySection && !hideSpotify ? (
             <div
               style={{
                 display: "flex",
@@ -538,10 +539,10 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
               }}
             >
               <img
-                src={`data:image/png;base64,${
+                src={getImageDataUri(
                   albumCover ??
                   (theme === "dark" ? UnknownIconLight : UnknownIconDark)
-                }`}
+                )}
                 alt="Album Cover"
                 style={{
                   border: data.spotify.album_art_url
@@ -603,7 +604,7 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
               </div>
             </div>
           ) : null}
-          {showMusicActivity ? (
+          {showMusicActivity && showActivitySection ? (
             <div
               style={{
                 display: "flex",
@@ -615,10 +616,10 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
               }}
             >
               <img
-                src={`data:image/png;base64,${
+                src={getImageDataUri(
                   albumCover ??
                   (theme === "dark" ? UnknownIconLight : UnknownIconDark)
-                }`}
+                )}
                 alt="Album Cover"
                 style={{
                   border: musicActivity!.assets?.large_image
@@ -682,10 +683,10 @@ export const ProfileCard: React.FC<ProfileCardProps> = ({
               </div>
             </div>
           ) : null}
-          {!activity &&
+          {showActivitySection &&
+          activities.length === 0 &&
           (!data.listening_to_spotify || hideSpotify) &&
-          !showMusicActivity &&
-          !hideActivity ? (
+          !showMusicActivity ? (
             <div
               style={{
                 display: "flex",

--- a/src/utils/fetchUserImages.ts
+++ b/src/utils/fetchUserImages.ts
@@ -7,8 +7,6 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
   let avatar: string;
   let avatarDecoration: string | null = null;
   let clanBadge: string | null = null;
-  let assetLargeImage: string | null = null;
-  let assetSmallImage: string | null = null;
   let userEmoji: string | null = null;
   let albumCover: string | null = null;
 
@@ -35,8 +33,7 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
       (activity) =>
         !settings.ignoreAppId?.includes(activity.application_id ?? "")
     );
-  const activity: Activity | undefined =
-    activities.length > 0 ? activities[0] : undefined;
+
 
   if (data.discord_user.avatar) {
     avatar = await encodeBase64(
@@ -76,23 +73,51 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
     );
   }
 
-  if (activity?.assets?.large_image)
-    assetLargeImage = await encodeBase64(
-      activity.assets?.large_image.startsWith("mp:external/")
-        ? `${activity.assets.large_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
-        : `https://cdn.discordapp.com/app-assets/${activity.application_id}/${activity.assets.large_image}.webp`,
-      ImageSize.ACTIVITY_LARGE,
-      settings.theme
-    );
+  const activityImages: Array<{ largeImage: string | null; smallImage: string | null }> = [];
+  for (const act of activities) {
+    let largeImage: string | null = null;
+    let smallImage: string | null = null;
 
-  if (activity?.assets?.small_image)
-    assetSmallImage = await encodeBase64(
-      activity.assets.small_image.startsWith("mp:external/")
-        ? `${activity.assets.small_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
-        : `https://cdn.discordapp.com/app-assets/${activity.application_id}/${activity.assets.small_image}.webp`,
-      ImageSize.ACTIVITY_SMALL,
-      settings.theme
-    );
+    if (act.assets?.large_image) {
+      largeImage = await encodeBase64(
+        act.assets.large_image.startsWith("mp:external/")
+          ? `${act.assets.large_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
+          : `https://cdn.discordapp.com/app-assets/${act.application_id}/${act.assets.large_image}.webp`,
+        ImageSize.ACTIVITY_LARGE,
+        settings.theme
+      );
+    } else if (act.application_id) {
+      try {
+        const appInfo = await fetch(
+          `https://discord.com/api/v9/applications/${act.application_id}/rpc`,
+          {
+            next: { revalidate: 86400 } // Cache application details for 1 day
+          }
+        ).then(res => res.ok ? res.json() as Promise<{ icon?: string } | null> : null);
+
+        if (appInfo && appInfo.icon) {
+          largeImage = await encodeBase64(
+            `https://cdn.discordapp.com/app-icons/${act.application_id}/${appInfo.icon}.webp`,
+            ImageSize.ACTIVITY_LARGE,
+            settings.theme
+          );
+        }
+      } catch (error) {
+        console.error(`Failed to fetch fallback icon for app ${act.application_id}:`, error);
+      }
+    }
+
+    if (act.assets?.small_image)
+      smallImage = await encodeBase64(
+        act.assets.small_image.startsWith("mp:external/")
+          ? `${act.assets.small_image.replace(/mp:external\/([^\/]*)\/(http[s])/g, "$2:/")}`
+          : `https://cdn.discordapp.com/app-assets/${act.application_id}/${act.assets.small_image}.webp`,
+        ImageSize.ACTIVITY_SMALL,
+        settings.theme
+      );
+
+    activityImages.push({ largeImage, smallImage });
+  }
 
   if (userStatus?.emoji?.id)
     userEmoji = await encodeBase64(
@@ -122,8 +147,7 @@ export async function fetchUserImages(data: Data, settings: ProfileSettings) {
     avatar,
     clanBadge,
     avatarDecoration,
-    assetLargeImage,
-    assetSmallImage,
+    activityImages,
     userEmoji,
     albumCover,
   };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -66,3 +66,21 @@ export const ImageSize = {
   ACTIVITY_LARGE: 128,
   ACTIVITY_SMALL: 32,
 };
+
+export function getImageDataUri(base64: string | null): string {
+  if (!base64) return "";
+  if (base64.startsWith("data:")) return base64; // already a data URI
+
+  let mime = "image/png";
+  if (base64.startsWith("UklGR")) {
+    mime = "image/webp";
+  } else if (base64.startsWith("R0lGOD")) {
+    mime = "image/gif";
+  } else if (base64.startsWith("/9j/")) {
+    mime = "image/jpeg";
+  } else if (base64.startsWith("iVBORw")) {
+    mime = "image/png";
+  }
+
+  return `data:${mime};base64,${base64}`;
+}


### PR DESCRIPTION
This PR adds concurrent rendering for Spotify/other music listening activities alongside game activities (previously hidden). It also adds a fallback RPC icon fetcher to download game icons for process-detected games that lack Rich Presence assets, and a dynamic mime-type resolver to prevent SVG rendering issues.